### PR TITLE
Android dev: fixed all platform navigation header to content offset problem

### DIFF
--- a/composeApp/src/commonMain/kotlin/composes/NavigationHeader.kt
+++ b/composeApp/src/commonMain/kotlin/composes/NavigationHeader.kt
@@ -1,5 +1,6 @@
 package composes
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
@@ -36,6 +37,7 @@ fun NavigationHeader(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier
                     .fillMaxWidth().height(configuration.calculateHeight)
+                    .background(configuration.color.surface.value)
                     .padding(horizontal = 12.dp)
                     .padding(top = 16.dp, bottom = 8.dp)
                     .statusBarsPadding()

--- a/composeApp/src/commonMain/kotlin/composes/NavigationView.kt
+++ b/composeApp/src/commonMain/kotlin/composes/NavigationView.kt
@@ -1,12 +1,16 @@
 package composes
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
@@ -42,13 +46,21 @@ data class NavigationView(
     @Composable
     override fun Content() {
         val configuration: NavigationHeaderConfiguration = NavigationHeaderConfiguration.defaultConfiguration
+        val scrollState = rememberScrollState()
         val navigator = LocalNavigator.currentOrThrow
-        Surface {
-            NavigationHeader(title, configuration, trailing)
+        val topOffset = NavigationHeaderConfiguration.defaultConfiguration.headerHeight + 28.dp
 
-            Box(Modifier.fillMaxSize().background(configuration.color.background.value)) {
-                content(navigator)
-            }
+        Surface {
+            NavigationHeader("Experimental functions")
+
+            Column(
+                verticalArrangement = Arrangement.Top,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxSize()
+                    .background(MaterialTheme.colors.background)
+                    .verticalScroll(scrollState)
+                    .safeContentPadding().padding(top = topOffset)
+            ) { content(navigator) }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/data/SpecificConfiguration.kt
+++ b/composeApp/src/commonMain/kotlin/data/SpecificConfiguration.kt
@@ -85,6 +85,7 @@ data class NavigationHeaderConfiguration(
             )
     }
 
+    
     val statusBarPadding: Dp
         @Composable
         get() = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()

--- a/composeApp/src/commonMain/kotlin/screens/ColorPreviewer.kt
+++ b/composeApp/src/commonMain/kotlin/screens/ColorPreviewer.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import composes.NavigationHeader
 import composes.contrastColor
+import data.NavigationHeaderConfiguration
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 object ColorPreviewer : Screen {
@@ -24,6 +25,7 @@ object ColorPreviewer : Screen {
     @Preview
     override fun Content() {
         val scrollState = rememberScrollState()
+        val topOffset = NavigationHeaderConfiguration.defaultConfiguration.headerHeight + 28.dp
 
         Surface {
             NavigationHeader("Color preview")
@@ -34,7 +36,7 @@ object ColorPreviewer : Screen {
                 modifier = Modifier
                     .verticalScroll(scrollState)
                     .safeContentPadding()
-                    .padding(top = 90.dp)
+                    .padding(top = topOffset)
             ) {
                 ColorCard("primary", MaterialTheme.colors.primary)
                 ColorCard("primaryVariant", MaterialTheme.colors.primaryVariant)

--- a/composeApp/src/commonMain/kotlin/screens/ExperimentalComponentsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/screens/ExperimentalComponentsScreen.kt
@@ -43,6 +43,7 @@ private fun ComponentA(
     textStyle: TextStyle,
 ) {
     val config = ExperimentalSpecificComponentsConfiguration.default
+    val topOffset = NavigationHeaderConfiguration.defaultConfiguration.headerHeight + 28.dp
 
     Surface {
         NavigationHeader("Component specific", NavigationHeaderConfiguration(color = config.surface))
@@ -53,7 +54,7 @@ private fun ComponentA(
             modifier = Modifier
                 .fillMaxSize()
                 .background(config.primaryColor.value)
-                .safeContentPadding()
+                .safeContentPadding().padding(top = topOffset)
         ) {
             Image(
                 painter = painterResource(config.platform.logo),
@@ -64,7 +65,7 @@ private fun ComponentA(
             Spacer(Modifier.height(12.dp))
 
             val apiTitle = config.platform.name + " " + config.platform.version
-            Text(apiTitle, fontSize = 7.2.em, fontWeight = FontWeight.Bold, color = textStyle.color)
+            Text(apiTitle, fontSize = 32.sp, fontWeight = FontWeight.Bold, color = textStyle.color)
 
             Spacer(Modifier.height(12.dp))
 

--- a/composeApp/src/commonMain/kotlin/screens/ExperimentalFunListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/screens/ExperimentalFunListScreen.kt
@@ -24,10 +24,10 @@ object ExperimentalFunListScreen : Screen {
     override fun Content() {
         val scrollState = rememberScrollState()
         val navigator = LocalNavigator.currentOrThrow
-        val topOffset = NavigationHeaderConfiguration.defaultConfiguration.headerHeight
+        val topOffset = NavigationHeaderConfiguration.defaultConfiguration.headerHeight + 28.dp
 
         Surface {
-            NavigationHeader("Experimental functions(${topOffset})")
+            NavigationHeader("Experimental functions")
 
             Column(
                 verticalArrangement = Arrangement.Top,

--- a/composeApp/src/commonMain/kotlin/screens/InfoScreen.kt
+++ b/composeApp/src/commonMain/kotlin/screens/InfoScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.core.screen.Screen
 import composes.NavigationHeader
 import composes.SnapAlert
+import data.NavigationHeaderConfiguration
 import data.SpecificConfiguration
 import io.kamel.image.KamelImage
 import io.kamel.image.asyncPainterResource
@@ -30,6 +31,7 @@ object InfoScreen : Screen {
             animationSpec = tween(durationMillis = 400),
             label = "SnackBar offset transition"
         )
+        val topOffset = NavigationHeaderConfiguration.defaultConfiguration.headerHeight + 28.dp
 
         // On appear show snack bar
         LaunchedEffect(Unit) {
@@ -51,7 +53,7 @@ object InfoScreen : Screen {
             Column(
                 verticalArrangement = Arrangement.Bottom,
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.fillMaxSize().safeContentPadding()
+                modifier = Modifier.fillMaxSize().safeContentPadding().padding(top = topOffset)
             ) {
                 SnapAlert(
                     message = "LifeMark 2024 Dev version 0.1.0",


### PR DESCRIPTION
### Defaut configuration
```kotlin
val NavigationHeaderConfiguration.Companion.defaultConfiguration: NavigationHeaderConfiguration
    get() = NavigationHeaderConfiguration(
        iconSize = 38.dp,
        padding = PaddingValues(12.dp, 16.dp, 12.dp, 8.dp),
        color = SurfaceColors.defaultNavigatorColors,
        text = TextStyle(
            fontWeight = FontWeight.Medium,
            fontSize = 18.sp,
            color = SurfaceColors.defaultNavigatorColors.foreground.value
        )
    )

// ...

val statusBarPadding: Dp
        @Composable
        get() = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
``` 

### ScreenShot
![Screenshot_20240422_200812](https://github.com/aczeccssa/LifeMark-KMM/assets/92659677/c351d5a1-a790-4a88-8f7c-b621caad291e)
